### PR TITLE
Create new functions for search analytics

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,15 +3,25 @@ const gsc = require('./lib/gsc');
 const date = require('./lib/date');
 const bigquery = require('./lib/bigquery');
 
-searchAnalyticsQueries = async (req, res) => {
-  const authData =  await auth(),
-      AnalyticsRows = [],
-      searchAnalyticsQueries = [],
-      sites = process.env.SITE_LIST.split(',');
+exports.gscDataLoader = async (req, res) => {
+  let authData = await auth();
+
+  const data = {},
+        errorsCountRows = [],
+        searchAnalyticsRows = [],
+        sitemapsRows = [],
+        errorSamplesRows = [],
+        analyticsRows = [],
+        searchAnalyticsQueries = [],
+        sites = process.env.SITE_LIST.split(',');
 
   for(site of sites) {
-    AnalyticsRows.push(await gsc.searchAnalytics(authData.client, site, date.threeDaysAgo(), date.currentDay(), ["query"]));
-    AnalyticsRows.forEach(row => {
+    errorsCountRows.push(await gsc.urlCrawlErrorsCounts(authData.client, site));
+    searchAnalyticsRows.push(await gsc.searchAnalytics(authData.client, site, date.threeDaysAgo(), date.currentDay()));
+    sitemapsRows.push(await gsc.sitemaps(authData.client, site));
+    errorSamplesRows.push(await gsc.errorsSamples(authData.client, site));
+    analyticsRows.push(await gsc.searchAnalytics(authData.client, site, date.threeDaysAgo(), date.currentDay(), ["query"]));
+    analyticsRows.forEach(row => {
       row.data.forEach(fields => {
         searchAnalyticsQueries.push({
           siteUrl: site,
@@ -24,31 +34,11 @@ searchAnalyticsQueries = async (req, res) => {
         });
       });
     });
-  }
-  await bigquery.insert('search_analytics_queries', searchAnalyticsQueries);
-  res.send();
-}
-
-exports.gscDataLoader = async (req, res) => {
-  let authData = await auth();
-
-  let data = {},
-      errorsCountRows = [],
-      searchAnalyticsRows = [],
-      sitemapsRows = [],
-      errorSamplesRows = [],
-      sites = process.env.SITE_LIST.split(',');
-
-  for(site of sites) {
-    errorsCountRows.push(await gsc.urlCrawlErrorsCounts(authData.client, site));
-    searchAnalyticsRows.push(await gsc.searchAnalytics(authData.client, site, date.threeDaysAgo(), date.currentDay()));
-    sitemapsRows.push(await gsc.sitemaps(authData.client, site));
-    errorSamplesRows.push(await gsc.errorsSamples(authData.client, site));
   };
   await bigquery.insert('errors_count', errorsCountRows);
   await bigquery.insert('search_analytics', searchAnalyticsRows);
   await bigquery.insert('sitemaps', sitemapsRows);
   await bigquery.insert('errors_samples', errorSamplesRows);
-
+  await bigquery.insert('search_analytics_queries', searchAnalyticsQueries);
   res.send();
 };

--- a/index.js
+++ b/index.js
@@ -4,15 +4,15 @@ const date = require('./lib/date');
 const bigquery = require('./lib/bigquery');
 
 searchAnalyticsQueries = async (req, res) => {
-  let authData =  await auth(),
+  const authData =  await auth(),
       AnalyticsRows = [],
       searchAnalyticsQueries = [],
-      sites = ['https://www.bidu.com.br'];
+      sites = process.env.SITE_LIST.split(',');
 
   for(site of sites) {
     AnalyticsRows.push(await gsc.searchAnalytics(authData.client, site, date.threeDaysAgo(), date.currentDay(), ["query"]));
-    for(let row of AnalyticsRows) {
-      for(let fields of row.data) {
+    AnalyticsRows.forEach(row => {
+      row.data.forEach(fields => {
         searchAnalyticsQueries.push({
           siteUrl: site,
           createdAt: new Date(),
@@ -22,8 +22,8 @@ searchAnalyticsQueries = async (req, res) => {
           ctr: fields.ctr,
           position: fields.position
         });
-      }
-    }
+      });
+    });
   }
   await bigquery.insert('search_analytics_queries', searchAnalyticsQueries);
   res.send();

--- a/index.js
+++ b/index.js
@@ -4,15 +4,15 @@ const date = require('./lib/date');
 const bigquery = require('./lib/bigquery');
 
 exports.gscDataLoader = async (req, res) => {
-  let authData = await auth();
+  let authData = await auth(),
+      searchAnalyticsQueries = [],
+      searchAnalyticsResult = [];
 
   const data = {},
         errorsCountRows = [],
         searchAnalyticsRows = [],
         sitemapsRows = [],
         errorSamplesRows = [],
-        analyticsRows = [],
-        searchAnalyticsQueries = [],
         sites = process.env.SITE_LIST.split(',');
 
   for(site of sites) {
@@ -21,26 +21,13 @@ exports.gscDataLoader = async (req, res) => {
     sitemapsRows.push(await gsc.sitemaps(authData.client, site));
     errorSamplesRows.push(await gsc.errorsSamples(authData.client, site));
 
-    let searchAnalyticsResult = await gsc.searchAnalytics(authData.client, site, date.threeDaysAgo(), date.currentDay(), ["query"]);
-    analyticsRows.push(searchAnalyticsResult);
-    analyticsRows.forEach(row => {
-      row.data.forEach(fields => {
-        searchAnalyticsQueries.push({
-          siteUrl: site,
-          createdAt: new Date(),
-          key: fields.keys[0],
-          clicks: fields.clicks,
-          impressions: fields.impressions,
-          ctr: fields.ctr,
-          position: fields.position
-        });
-      });
-    });
+    searchAnalyticsResult = await gsc.searchAnalytics(authData.client, site, date.threeDaysAgo(), date.currentDay(), ["query"]);
+    searchAnalyticsQueries.push(await gsc.searchAnalyticsQueries(searchAnalyticsResult, site));
   };
   await bigquery.insert('errors_count', errorsCountRows);
   await bigquery.insert('search_analytics', searchAnalyticsRows);
   await bigquery.insert('sitemaps', sitemapsRows);
   await bigquery.insert('errors_samples', errorSamplesRows);
-  await bigquery.insert('search_analytics_queries', searchAnalyticsQueries);
+  await bigquery.insert('search_analytics_queries', searchAnalyticsQueries.reduce((result, current) => result.concat(current)));
   res.send();
 };

--- a/index.js
+++ b/index.js
@@ -20,7 +20,9 @@ exports.gscDataLoader = async (req, res) => {
     searchAnalyticsRows.push(await gsc.searchAnalytics(authData.client, site, date.threeDaysAgo(), date.currentDay()));
     sitemapsRows.push(await gsc.sitemaps(authData.client, site));
     errorSamplesRows.push(await gsc.errorsSamples(authData.client, site));
-    analyticsRows.push(await gsc.searchAnalytics(authData.client, site, date.threeDaysAgo(), date.currentDay(), ["query"]));
+
+    let searchAnalyticsResult = await gsc.searchAnalytics(authData.client, site, date.threeDaysAgo(), date.currentDay(), ["query"]);
+    analyticsRows.push(searchAnalyticsResult);
     analyticsRows.forEach(row => {
       row.data.forEach(fields => {
         searchAnalyticsQueries.push({

--- a/lib/gsc.js
+++ b/lib/gsc.js
@@ -47,6 +47,25 @@ module.exports = {
       });
     });
   },
+  searchAnalyticsQueries: async function(searchAnalyticsResult, site) {
+    let analyticsRows = [],
+        queries = []
+    analyticsRows.push(searchAnalyticsResult);
+    analyticsRows.forEach(row => {
+      row.data.forEach(fields => {
+        queries.push({
+          siteUrl: site,
+          createdAt: new Date(),
+          key: fields.keys[0],
+          clicks: fields.clicks,
+          impressions: fields.impressions,
+          ctr: fields.ctr,
+          position: fields.position
+        });
+      });
+    });
+    return queries;
+  },
   sitemaps: (authClient, siteUrl) => {
     return new Promise((resolve, reject) => {
       let queryParams = { auth: authClient, siteUrl };

--- a/lib/gsc.js
+++ b/lib/gsc.js
@@ -25,12 +25,13 @@ module.exports = {
       });
     });
   },
-  searchAnalytics: (authClient, siteUrl, startDate, endDate) => {
+  searchAnalytics: (authClient, siteUrl, startDate, endDate, dimensions) => {
+    dimensions = dimensions || null;
     return new Promise((resolve, reject) => {
       let today = new Date(),
           queryParams = {
             auth: authClient, siteUrl,
-            resource:{startDate, endDate}
+            resource:{startDate, endDate, dimensions}
           };
       console.log(`Start getting searchanalytics from ${siteUrl}`);
       webmasters.searchanalytics.query(queryParams, (err, response) => {

--- a/lib/gsc.js
+++ b/lib/gsc.js
@@ -47,7 +47,7 @@ module.exports = {
       });
     });
   },
-  searchAnalyticsQueries: async function(searchAnalyticsResult, site) {
+  searchAnalyticsQueries: (searchAnalyticsResult, site) => {
     let analyticsRows = [],
         queries = []
     analyticsRows.push(searchAnalyticsResult);

--- a/schemas/search_analytics_queries.json
+++ b/schemas/search_analytics_queries.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "siteUrl",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "createdAt",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "key",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  }
+  {
+    "name": "position",
+    "type": "FLOAT",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "ctr",
+    "type": "FLOAT",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "impressions",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "clicks",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  }
+]


### PR DESCRIPTION
A pedidos do pessoal de marketing, criei outra função do search analytics que ao invés de pegar o total de ctr, impressions, palavras de todo o site, ele filtra para cada palavra. Resoolvi criar uma outra tabela para não afetar os outros dados e também criei uma outra função no index.js para não quebrar a lógica das outras funções, mesmo assim, aproveitei ao maximo as funções já criadas.

A tabela no bigquery ja foi criada e todo o processo ja funciona desde sua chamada até a inserção de dados. O que falta agora pós merge, é atualizar o cloudfunctions e fazer o robozinho do zapier que bate todos os dias na função gscDataLoader , bater também na searchAnalyticsQueries.

Exemplo da inserção:
![image](https://user-images.githubusercontent.com/24498376/49533531-5e96c980-f8a6-11e8-91ba-75b5d3650974.png)
